### PR TITLE
Factory function to create a catalog by name, avoiding the profile call.

### DIFF
--- a/pyechonest/catalog.py
+++ b/pyechonest/catalog.py
@@ -22,6 +22,17 @@ import artist, song
 # deal with datetime in json
 dthandler = lambda obj: obj.isoformat() if isinstance(obj, datetime.datetime) else None
 
+def create_catalog_by_name(name, T="general"):
+    """
+    Creates a catalog object, with a given name. Does not check to see if the catalog already exists.
+
+    Create a catalog object like
+    """
+    result = util.callm("catalog/create", {}, POST=True, 
+                            data={"name":name, "type":T})
+    result = result['response']
+    return Catalog(result['id'], **dict( (k,result[k]) for k in ('name', 'type')))
+
 class Catalog(CatalogProxy):
     """
     A Catalog object


### PR DESCRIPTION
There doesn't appear to be a way to create a catalog in Pyechonest without making a profile call first. This patch adds a factory function to catalog.py, "create_catalog_by_name", that creates a catalog without the profile call, then returns an initialized Catalog object without any additional calls.
