### PR TITLE
Simplify expression.

### DIFF
--- a/pyechonest/util.py
+++ b/pyechonest/util.py
@@ -204,7 +204,7 @@ def callm(method, param_dict, POST=False, socket_timeout=None, data=None):
         socket.setdefaulttimeout(socket_timeout)
 
         if(POST):
-            if (not method == 'track/upload') or ((method == 'track/upload') and 'url' in param_dict):
+            if (not method == 'track/upload') or ('url' in param_dict):
                 """
                 this is a normal POST call
                 """


### PR DESCRIPTION
Remove unnecessary element from expression. The first part of the 'or' expression already checks it.
