### PR TITLE
playlist.py: adding .copy() to locals() preventing kwargs to be sent …

### DIFF
--- a/pyechonest/playlist.py
+++ b/pyechonest/playlist.py
@@ -48,7 +48,7 @@ def basic(type='artist-radio', artist_id=None, artist=None, song_id=None, song=N
     limit = str(limit).lower()
     dmca = str(dmca).lower()
 
-    kwargs = locals()
+    kwargs = locals().copy()
     kwargs['bucket'] = kwargs['buckets']
     del kwargs['buckets']
     kwargs['genre'] = kwargs['genres']
@@ -199,7 +199,7 @@ def static(type='artist', artist_pick='song_hotttnesss-desc', variety=.5, artist
     if source_catalog and isinstance(source_catalog, catalog.Catalog):
         source_catalog = source_catalog.id
     dmca = str(dmca).lower()
-    kwargs = locals()
+    kwargs = locals().copy()
     kwargs['bucket'] = kwargs['buckets'] or []
     del kwargs['buckets']
     kwargs['genre'] = kwargs['genres']


### PR DESCRIPTION
…over HTTP

Both static() and basic() functions use kwargs = locals() in order to retrieve the long list of keyword arguments as a dictionary. This is practical, however in python 2.7.6, the actual "kwargs" variable does get scanned by locals() and added as a reference to that dictionary. This ends in kwargs == {...variables key-value pairs..., "kwargs": {the same key-value pairs as before}} and that ugly variable is then sent online to the Echo Nest API.. Using kwargs = locals().copy() removes that kwargs=>kwargs embedded key-value pair.

This also occurs in song.py... Let us check that later.
